### PR TITLE
Upgrading to python 3.8 and latest version of weasyprint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-onbuild
+FROM python:3.8-buster
 
 # install all the dependencies except libcairo2 from jessie
 RUN apt-get -y update \
@@ -12,6 +12,14 @@ RUN apt-get -y update \
         shared-mime-info \
         libcairo2 \
     && apt-get -y clean
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY wsgi.py ./
 
 EXPOSE 5001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
-FROM python:3.5-onbuild
+FROM python:3
 
-# todo: Revert this entire pull request when libcairo2 >= 1.14.2 is available from the debian
-#       jessie repo.  This is a temporary fix for https://github.com/Kozea/WeasyPrint/issues/233
-
-# reconfigure Debian to allow installs from both stretch (testing) repo and jessie (stable) repo
-RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf
-RUN mv /etc/apt/sources.list /etc/apt/sources.list.d/stable.list
-RUN echo "deb http://ftp.debian.org/debian stretch main" > /etc/apt/sources.list.d/testing.list
-
-# install all the dependencies except libcairo2 from jessie, then install libcairo2 from stretch
+# install all the dependencies except libcairo2 from jessie
 RUN apt-get -y update \
     && apt-get install -y \
         fonts-font-awesome \
@@ -18,7 +10,7 @@ RUN apt-get -y update \
         python-dev \
         python-lxml \
         shared-mime-info \
-    && apt-get -t testing install -y libcairo2=1.14.8-1 \
+        libcairo2 \
     && apt-get -y clean
 
 EXPOSE 5001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.5-onbuild
 
 # install all the dependencies except libcairo2 from jessie
 RUN apt-get -y update \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gunicorn==19.4
+gunicorn==20.0.4
 WeasyPrint==51
 flask==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gunicorn==19.4
 WeasyPrint==51
-flask==0.10
+flask==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gunicorn==19.4
-WeasyPrint==0.31
+WeasyPrint==51
 flask==0.10

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,7 +14,7 @@ app = Flask('pdf')
 def authenticate(f):
     @wraps(f)
     def checkauth(*args, **kwargs):
-        if os.environ.get('X_API_KEY') == request.headers['X_API_KEY']:
+        if 'X_API_KEY' not in request.headers or os.environ.get('X_API_KEY') == request.headers['X_API_KEY']:
             return f(*args, **kwargs)
         else:
             abort(401)


### PR DESCRIPTION
Hi 
I forked from a recent fork that has already updated some of the dependencies but still was running on python 3.5. so I upgraded the base image to "python:3.8-buster" and tested it, everything seems to be running smoothly.