### PR TITLE
Fix authentication bypass and add usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,36 @@
 
 [![Build Status](https://travis-ci.org/aquavitae/docker-weasyprint.svg?branch=master)](https://travis-ci.org/aquavitae/docker-weasyprint)
 
-[Weasyprint](http://weasyprint.org/) as a microservice in a docker image.
+[Weasyprint](http://weasyprint.org/) as a microservice in a Docker image.
 
 # Usage
 
-Run the docker image, exposing port 5001
+Run the Docker image, exposing port 5001
 
-```
+```bash
 docker run -p 5001:5001 aquavitae/weasyprint
 ```
 
-A `POST` to port `/pdf` on port 5001 with an html body with give a response containing a PDF. The filename may be set using a query parameter, e.g.:
+A `POST` to port `/pdf` on port 5001 with an HTML body with give a response containing a PDF. The filename may be set using a query parameter, e.g.:
 
-```
+```bash
 curl -X POST -d @source.html http://127.0.0.1:5001/pdf?filename=result.pdf
 ```
 
-This will use the file `source.html` and return a response with `Content-Type: application/pdf` and `Content-Disposition: inline; filename=result.pdf` headers.  The body of the response will be the PDF.
+This will use the file `source.html` and return a response with `Content-Type: application/pdf` and `Content-Disposition: inline; filename=result.pdf` headers. The body of the response will be the PDF.
 
 In addition `/health` is a health check endpoint and a `GET` returns 'ok'.
+
+# Security
+
+To restrict access to only trusted clients, set the environment variable `X_API_KEY` with a client secret when running the image:
+
+```bash
+docker run -e X_API_KEY=somethingMOREsecure -p 5001:5001 aquavitae/weasyprint
+```
+
+PDF requests will now only be accepted if they provide the matching header:
+
+```bash
+curl -X POST -H "X_API_KEY: somethingMOREsecure" -d @source.html http://127.0.0.1:5001/pdf?filename=result.pdf
+```

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,19 +14,14 @@ app = Flask('pdf')
 def authenticate(f):
     @wraps(f)
     def checkauth(*args, **kwargs):
-        if 'X_API_KEY' not in request.headers or os.environ.get('X_API_KEY') == request.headers['X_API_KEY']:
-            return f(*args, **kwargs)
-        else:
-            abort(401)
+        if 'X_API_KEY' in os.environ:
+            if 'X_API_KEY' not in request.headers:
+                abort(401)
+            if os.environ.get('X_API_KEY') != request.headers.get('X_API_KEY'):
+                abort(403)
+        return f(*args, **kwargs)
 
     return checkauth
-
-
-def auth():
-    if app.config.from_envvar('X_API_KEY') == request.headers['X_API_KEY']:
-        return True
-    else:
-        abort(401)
 
 
 @app.route('/health')


### PR DESCRIPTION
This change ensures authentication is always enforced when it is configured (environment variable is present).

Previously the auth check would reject requests with a non-matching header, but would still accept any request which didn't provide the header in the first place (the common case), allowing authentication bypass.

You can still disable the auth check by omitting the environment variable.
